### PR TITLE
Implemented hashtable generation from symbols

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -3,21 +3,25 @@
 #include <libstapsdt.h>
 
 int main( int argc, char *argv[] ) {
-  int (*fireProbe)();
+  SDTProvider_t *provider;
+  SDTProbe_t *probe;
 
   if(argc != 3) {
     printf("usage: demo PROVIDER PROBE\n");
     return -1;
   }
 
-  fireProbe = registerProbe(argv[1], argv[2]);
+  provider = providerInit(argv[1]);
+  probe = providerAddProbe(provider, argv[2]);
 
-  if(fireProbe == NULL)
+  if(providerLoad(provider) == -1) {
+    printf("Something went wrong...\n");
     return -1;
+  }
 
   while(1) {
     printf("Firing probe...\n");
-    fireProbe();
+    probeFire(probe);
     printf("Probe fired!\n");
     sleep(3);
   }

--- a/src/hash-table.c
+++ b/src/hash-table.c
@@ -1,0 +1,42 @@
+#include "dynamic-symbols.h"
+
+#define possibleBucketSizesCount 17
+size_t possibleBucketSizes[] = {1, 3, 7, 13, 31, 61, 127, 251, 509, 1021, 2039, 4093, 8191, 16381, 32749, 65521, 131071};
+
+static size_t getRecommendedBucketSize(size_t NumSymbols) {
+  // Fallback
+  size_t bucketSize = NumSymbols * 2;
+
+  for (int i=0; i < possibleBucketSizesCount; i++) {
+    if (NumSymbols < possibleBucketSizes[i]) {
+      bucketSize = possibleBucketSizes[i];
+      break;
+    }
+  }
+
+  return bucketSize;
+}
+
+// TODO (mmarchini) maybe we should use GNU Hash instead
+size_t hashTableFromSymbolTable(DynamicSymbolTable *table, uint32_t **hashTable) {
+  DynamicSymbolList *current;
+  uint32_t nBuckets = getRecommendedBucketSize(table->count),
+           nChains = table->count + 1;
+  size_t hashTableSize = (nBuckets + nChains + 2);
+
+  uint32_t *hashTable_ = (uint32_t *)calloc(sizeof(uint32_t), hashTableSize);
+  int idx, chainIdx=1;
+
+  hashTable_[0] = nBuckets;
+  hashTable_[1] = nChains;
+
+  for(current=table->symbols; current!=NULL; current=current->next) {
+    idx = elf_hash(current->symbol.string->str) % nBuckets;
+    hashTable_[2 + idx] = chainIdx;
+    hashTable_[2 + nBuckets + 1] = chainIdx + 1;
+    chainIdx++;
+  }
+
+  *hashTable = hashTable_;
+  return hashTableSize * sizeof(uint32_t);
+}

--- a/src/hash-table.h
+++ b/src/hash-table.h
@@ -1,0 +1,3 @@
+#include "dynamic-symbols.h"
+
+size_t hashTableFromSymbolTable(DynamicSymbolTable *table, uint32_t **hashTable);

--- a/src/libstapsdt.c
+++ b/src/libstapsdt.c
@@ -14,6 +14,7 @@
 #include "string-table.h"
 #include "shared-lib.h"
 #include "util.h"
+#include "libstapsdt.h"
 
 // ------------------------------------------------------------------------- //
 // TODO(matheus): dynamic strings creation
@@ -34,34 +35,78 @@ int createSharedLibrary(int fd, char *provider, char *probe) {
   return 0;
 }
 
-void *registerProbe(char *provider, char *probe) {
+SDTProvider_t *providerInit(char *name) {
+  SDTProvider_t *provider = (SDTProvider_t *) calloc(sizeof(SDTProvider_t), 1);
+  provider->probes = NULL;
+
+  provider->name = (char *) calloc(sizeof(char), strlen(name) + 1);
+  memcpy(provider->name, name, sizeof(char) * strlen(name) + 1);
+
+  return provider;
+}
+
+SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name) {
+  SDTProbeList_t *probeList = (SDTProbeList_t *) calloc(sizeof(SDTProbeList_t), 1);
+  probeList->probe._fire = NULL;
+
+  probeList->probe.name = (char *) calloc(sizeof(char), strlen(name) + 1);
+  memcpy(probeList->probe.name, name, sizeof(char) * strlen(name) + 1);
+
+  probeList->next = provider->probes;
+  provider->probes = probeList;
+
+  return &(probeList->probe);
+}
+
+int providerLoad(SDTProvider_t *provider) {
+  // TODO (mmarchini) multiple probes, better code to handle that
+  SDTProbe_t *probe = &(provider->probes->probe);
+
   int fd;
   void *handle;
   void *fireProbe;
-  char filename[sizeof("/tmp/") + sizeof(provider) + sizeof(probe) +
+  char filename[sizeof("/tmp/") + sizeof(provider->name) + sizeof(probe->name) +
                 sizeof("XXXXXX") + 2];
   char *error;
 
-  sprintf(filename, "/tmp/%s-%s-XXXXXX", provider, probe);
+  sprintf(filename, "/tmp/%s-%s-XXXXXX", provider->name, probe->name);
 
   if ((fd = mkstemp(filename)) < 0) {
-    return NULL;
+    printf("Couldn't create '%s'\n", filename);
+    return -1;
   }
 
-  createSharedLibrary(fd, provider, probe);
+  createSharedLibrary(fd, provider->name, probe->name);
+  (void)close(fd);
+
   handle = dlopen(filename, RTLD_LAZY);
   if (!handle) {
     fputs(dlerror(), stderr);
-    return NULL;
+    return -1;
   }
 
-  fireProbe = dlsym(handle, PROBE_SYMBOL);
+  fireProbe = dlsym(handle, probe->name);
+  probe->_fire = fireProbe;
 
   if ((error = dlerror()) != NULL) {
     fputs(error, stderr);
-    return NULL;
+    return -1;
   }
 
-  (void)close(fd);
-  return fireProbe;
+  return 0;
+}
+
+void probeFire(SDTProbe_t *probe) {
+  ((void (*)())probe->_fire) ();
+}
+
+void providerDestroy(SDTProvider_t *provider) {
+  SDTProbeList_t *node=NULL, *next=NULL;
+  for(node=provider->probes; node!=NULL; node=next) {
+    free(node->probe.name);
+    next=node->next;
+    free(node);
+  }
+  free(provider->name);
+  free(provider);
 }

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -1,2 +1,25 @@
 
-void *registerProbe(char *provider, char *probe);
+typedef struct  {
+  char *name;
+  void *_fire;
+} SDTProbe_t;
+
+typedef struct SDTProbeList_ {
+  SDTProbe_t probe;
+  struct SDTProbeList_ *next;
+} SDTProbeList_t;
+
+typedef struct SDTProvider {
+  char *name;
+  SDTProbeList_t *probes;
+} SDTProvider_t;
+
+SDTProvider_t *providerInit(char *name);
+
+SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name);
+
+int providerLoad(SDTProvider_t *provider);
+
+void providerDestroy(SDTProvider_t *provider);
+
+void probeFire(SDTProbe_t *probe);

--- a/src/shared-lib.h
+++ b/src/shared-lib.h
@@ -6,8 +6,6 @@
 #include "sdtnote.h"
 #include "dynamic-symbols.h"
 
-#define PROBE_SYMBOL "lorem"
-
 typedef struct {
   Section
     *hash,

--- a/tests/test-memory-leaks.c
+++ b/tests/test-memory-leaks.c
@@ -3,14 +3,20 @@
 #include <libstapsdt.h>
 
 int main( int argc, char *argv[] ) {
-  int (*fireProbe)();
+  SDTProvider_t *provider;
+  SDTProbe_t *probe;
 
-  fireProbe = registerProbe("test-provider", "test-probe");
+  provider = providerInit("testProvider");
+  probe = providerAddProbe(provider, "testProbe");
 
-  if(fireProbe == NULL)
+  if(providerLoad(provider) == -1) {
+    printf("Something went wrong...\n");
     return -1;
+  }
 
-  fireProbe();
+  probeFire(probe);
+
+  providerDestroy(provider);
 
   return 0;
 }


### PR DESCRIPTION
Hashtable was fixed in code, making it impossible to change the probe
symbol's name used to load the fire function dynamically. A hash table
algorithm was implemented based on how other tools implement it and how
dlfcn loads it. Even though it should work for most cases, there's still
need to implement collision resolution on this algorithm, otherwise,
we'll have problems in the future.

Fixes: https://github.com/sthima/libstapsdt/issues/4