### PR TITLE
src: add probe arguments

### DIFF
--- a/example/demo.c
+++ b/example/demo.c
@@ -5,6 +5,8 @@
 int main( int argc, char *argv[] ) {
   SDTProvider_t *provider;
   SDTProbe_t *probe;
+  unsigned long long i=0;
+  int j=0;
 
   if(argc != 3) {
     printf("usage: demo PROVIDER PROBE\n");
@@ -12,7 +14,7 @@ int main( int argc, char *argv[] ) {
   }
 
   provider = providerInit(argv[1]);
-  probe = providerAddProbe(provider, argv[2]);
+  probe = providerAddProbe(provider, argv[2], 2, uint64, int64);
 
   if(providerLoad(provider) == -1) {
     printf("Something went wrong...\n");
@@ -21,7 +23,7 @@ int main( int argc, char *argv[] ) {
 
   while(1) {
     printf("Firing probe...\n");
-    probeFire(probe);
+    probeFire(probe, i++, j--);
     printf("Probe fired!\n");
     sleep(3);
   }

--- a/src/libstapsdt.c
+++ b/src/libstapsdt.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <dlfcn.h>
 #include <err.h>
 #include <fcntl.h>
@@ -16,14 +17,12 @@
 #include "util.h"
 #include "libstapsdt.h"
 
-// ------------------------------------------------------------------------- //
-// TODO(matheus): dynamic strings creation
-
-int createSharedLibrary(int fd, char *provider, char *probe) {
-  // Dynamic strings
+int createSharedLibrary(int fd, SDTProvider_t *provider) {
   DynElf *dynElf = dynElfInit(fd);
 
-  dynElfAddProbe(dynElf, provider, probe);
+  for(SDTProbeList_t *node=provider->probes; node != NULL; node = node->next) {
+    dynElfAddProbe(dynElf, &(node->probe));
+  }
 
   if(dynElfSave(dynElf) == -1) {
     return -1;
@@ -31,7 +30,6 @@ int createSharedLibrary(int fd, char *provider, char *probe) {
 
   dynElfClose(dynElf);
 
-  /* Finished */
   return 0;
 }
 
@@ -45,7 +43,12 @@ SDTProvider_t *providerInit(char *name) {
   return provider;
 }
 
-SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name) {
+SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name, int argCount, ...) {
+  int i;
+  va_list vl;
+  ArgType_t arg;
+  va_start(vl, argCount);
+
   SDTProbeList_t *probeList = (SDTProbeList_t *) calloc(sizeof(SDTProbeList_t), 1);
   probeList->probe._fire = NULL;
 
@@ -55,28 +58,37 @@ SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name) {
   probeList->next = provider->probes;
   provider->probes = probeList;
 
+  probeList->probe.argCount = argCount;
+
+  for(i=0; i < argCount; i++) {
+    arg = va_arg(vl, ArgType_t);
+    probeList->probe.argFmt[i] = arg;
+  }
+
+  for(; i<MAX_ARGUMENTS; i++) {
+    probeList->probe.argFmt[i] = noarg;
+  }
+
+  probeList->probe.provider = provider;
+
   return &(probeList->probe);
 }
 
 int providerLoad(SDTProvider_t *provider) {
-  // TODO (mmarchini) multiple probes, better code to handle that
-  SDTProbe_t *probe = &(provider->probes->probe);
-
   int fd;
   void *handle;
   void *fireProbe;
-  char filename[sizeof("/tmp/") + sizeof(provider->name) + sizeof(probe->name) +
-                sizeof("XXXXXX") + 2];
+  char filename[sizeof("/tmp/") + sizeof(provider->name) + sizeof("XXXXXX") + 1];
   char *error;
 
-  sprintf(filename, "/tmp/%s-%s-XXXXXX", provider->name, probe->name);
+  sprintf(filename, "/tmp/%s-XXXXXX", provider->name);
 
   if ((fd = mkstemp(filename)) < 0) {
     printf("Couldn't create '%s'\n", filename);
     return -1;
   }
 
-  createSharedLibrary(fd, provider->name, probe->name);
+  createSharedLibrary(fd, provider);
   (void)close(fd);
 
   handle = dlopen(filename, RTLD_LAZY);
@@ -85,8 +97,10 @@ int providerLoad(SDTProvider_t *provider) {
     return -1;
   }
 
-  fireProbe = dlsym(handle, probe->name);
-  probe->_fire = fireProbe;
+  for(SDTProbeList_t *node=provider->probes; node != NULL; node = node->next) {
+    fireProbe = dlsym(handle, node->probe.name);
+    node->probe._fire = fireProbe;
+  }
 
   if ((error = dlerror()) != NULL) {
     fputs(error, stderr);
@@ -96,8 +110,40 @@ int providerLoad(SDTProvider_t *provider) {
   return 0;
 }
 
-void probeFire(SDTProbe_t *probe) {
-  ((void (*)())probe->_fire) ();
+void probeFire(SDTProbe_t *probe, ...) {
+  va_list vl;
+  va_start(vl, probe);
+  uint64_t arg[6] = {0};
+  for(int i=0; i < probe->argCount; i++) {
+    arg[i] = va_arg(vl, uint64_t);
+  }
+
+  switch(probe->argCount) {
+    case 0:
+      ((void (*)())probe->_fire) ();
+      return;
+    case 1:
+      ((void (*)())probe->_fire) (arg[0]);
+      return;
+    case 2:
+      ((void (*)())probe->_fire) (arg[0], arg[1]);
+      return;
+    case 3:
+      ((void (*)())probe->_fire) (arg[0], arg[1], arg[2]);
+      return;
+    case 4:
+      ((void (*)())probe->_fire) (arg[0], arg[1], arg[2], arg[3]);
+      return;
+    case 5:
+      ((void (*)())probe->_fire) (arg[0], arg[1], arg[2], arg[3], arg[4]);
+      return;
+    case 6:
+      ((void (*)())probe->_fire) (arg[0], arg[1], arg[2], arg[3], arg[4], arg[5]);
+      return;
+    default:
+      ((void (*)())probe->_fire) ();
+      return;
+  }
 }
 
 void providerDestroy(SDTProvider_t *provider) {

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -1,7 +1,28 @@
+#ifndef _LIBSTAPSDT_H
+#define _LIBSTAPSDT_H
+#define MAX_ARGUMENTS 6
+
+typedef enum {
+  noarg = 0,
+  uint8 = 1,
+  int8 = -1,
+  uint16 = 2,
+  int16 = -2,
+  uint32 = 4,
+  int32 = -4,
+  uint64 = 8,
+  int64 = -8,
+} ArgType_t;
+
+
+struct SDTProvider;
 
 typedef struct  {
   char *name;
+  ArgType_t argFmt[MAX_ARGUMENTS];
   void *_fire;
+  struct SDTProvider *provider;
+  int argCount;
 } SDTProbe_t;
 
 typedef struct SDTProbeList_ {
@@ -16,10 +37,12 @@ typedef struct SDTProvider {
 
 SDTProvider_t *providerInit(char *name);
 
-SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name);
+SDTProbe_t *providerAddProbe(SDTProvider_t *provider, char *name, int argCount, ...);
 
 int providerLoad(SDTProvider_t *provider);
 
 void providerDestroy(SDTProvider_t *provider);
 
-void probeFire(SDTProbe_t *probe);
+void probeFire(SDTProbe_t *probe, ...);
+
+#endif

--- a/src/sdtnote.c
+++ b/src/sdtnote.c
@@ -1,8 +1,36 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "sdtnote.h"
 #include "util.h"
+
+
+// TODO (mmarchini) add other architectures (this only works for x86_64)
+char *regMap(int idx) {
+    switch (idx) {
+      case 0:
+      return "rdi";
+        break;
+      case 1:
+        return "rsi";
+        break;
+      case 2:
+        return "rdx";
+        break;
+      case 3:
+        return "rcx";
+        break;
+      case 4:
+        return "r8";
+        break;
+      case 5:
+        return "r9";
+        break;
+      default:
+        return NULL;
+    }
+}
 
 size_t sdtNoteSize(SDTNote *sdt) {
   size_t size = 0;
@@ -15,16 +43,17 @@ size_t sdtNoteSize(SDTNote *sdt) {
   return size;
 }
 
-SDTNote *sdtNoteInit(char *provider, char *probe) {
+SDTNote *sdtNoteInit(SDTProbe_t *probe) {
+  char buf[100];
   SDTNote *sdt = calloc(sizeof(SDTNote), 1);
-  size_t descsz = 0, providersz = strlen(provider) + 1,
-         probesz = strlen(probe) + 1;
+  size_t descsz = 0, providersz = strlen(probe->provider->name) + 1,
+         probesz = strlen(probe->name) + 1;
   sdt->header.n_type = NT_STAPSDT;
   sdt->header.n_namesz = sizeof(NT_STAPSDT_NAME);
 
   // TODO(matheus): should add pad if sizeof(NT_STAPSDT)%4 != 0
   sdt->name = calloc(sizeof(NT_STAPSDT_NAME), 1);
-  memcpy(sdt->name, NT_STAPSDT_NAME, strlen(NT_STAPSDT_NAME) + 1);
+  strncpy(sdt->name, NT_STAPSDT_NAME, strlen(NT_STAPSDT_NAME) + 1);
 
   sdt->content.probePC = -1;
   descsz += sizeof(sdt->content.probePC);
@@ -35,15 +64,27 @@ SDTNote *sdtNoteInit(char *provider, char *probe) {
 
   sdt->content.provider = calloc(providersz, 1);
   descsz += providersz;
-  memcpy(sdt->content.provider, provider, providersz);
+  strncpy(sdt->content.provider, probe->provider->name, providersz);
 
   sdt->content.probe = calloc(probesz, 1);
   descsz += probesz;
-  memcpy(sdt->content.probe, probe, probesz);
+  strncpy(sdt->content.probe, probe->name, probesz);
 
   sdt->content.argFmt = calloc(sizeof(char), 1);
   sdt->content.argFmt[0] = '\0';
-  descsz += sizeof(char);
+  for(int i=0; i < probe->argCount; i++) {
+    sprintf(buf, "%d@%%%s", probe->argFmt[i], regMap(i));
+
+
+    if(i==0) {
+      sdt->content.argFmt = realloc(sdt->content.argFmt, strlen(sdt->content.argFmt) + strlen(buf) + 1);
+      sprintf(sdt->content.argFmt, "%s", buf);
+    } else {
+      sdt->content.argFmt = realloc(sdt->content.argFmt, strlen(sdt->content.argFmt) + strlen(buf) + 2);
+      sprintf(&(sdt->content.argFmt[strlen(sdt->content.argFmt)]), " %s", buf);
+    }
+  }
+  descsz += strlen(sdt->content.argFmt) + 1;
 
   sdt->header.n_descsz = descsz;
 

--- a/src/sdtnote.h
+++ b/src/sdtnote.h
@@ -2,6 +2,7 @@
 #define _SDT_NOTE_H
 
 #include <libelf.h>
+#include "libstapsdt.h"
 
 #define NT_STAPSDT 3
 #define NT_STAPSDT_NAME "stapsdt"
@@ -24,7 +25,7 @@ typedef struct SDTNote_ {
 
 size_t sdtNoteSize(SDTNote *sdt);
 
-SDTNote *sdtNoteInit(char *provider, char *probe);
+SDTNote *sdtNoteInit(SDTProbe_t *probe);
 
 int sdtNoteToBuffer(SDTNote *sdt, char *buffer);
 

--- a/src/shared-lib.c
+++ b/src/shared-lib.c
@@ -164,9 +164,9 @@ DynElf *dynElfInit(int fd) {
   return dynElf;
 }
 
-int dynElfAddProbe(DynElf *dynElf, char *provider, char *probe) {
-  dynElf->sdtNote = sdtNoteInit(provider, probe);
-  dynamicSymbolTableAdd(dynElf->dynamicSymbols, probe);
+int dynElfAddProbe(DynElf *dynElf, SDTProbe_t *probe) {
+  dynElf->sdtNote = sdtNoteInit(probe);
+  dynamicSymbolTableAdd(dynElf->dynamicSymbols, probe->name);
 
   return 0;
 }

--- a/src/shared-lib.h
+++ b/src/shared-lib.h
@@ -36,7 +36,7 @@ typedef struct {
 
 DynElf *dynElfInit();
 
-int dynElfAddProbe(DynElf *dynElf, char *provider, char *probe);
+int dynElfAddProbe(DynElf *dynElf, SDTProbe_t *probe);
 
 int dynElfSave(DynElf *dynElf);
 

--- a/tests/test-memory-leaks.c
+++ b/tests/test-memory-leaks.c
@@ -7,14 +7,14 @@ int main( int argc, char *argv[] ) {
   SDTProbe_t *probe;
 
   provider = providerInit("testProvider");
-  probe = providerAddProbe(provider, "testProbe");
+  probe = providerAddProbe(provider, "testProbe", 4, int8, uint8, int64, uint64);
 
   if(providerLoad(provider) == -1) {
     printf("Something went wrong...\n");
     return -1;
   }
 
-  probeFire(probe);
+  probeFire(probe, 1, 2, 3, 4);
 
   providerDestroy(provider);
 


### PR DESCRIPTION
One of the main features of Systemtap's SDT probes is the ability to pass
arguments to a probe. Those arguments are stored in the processor's
registers, which can be read by other tools through information
available on the SDT note. This commit adds the same functionality,
although the current implementation only works on x86_64. In the future,
we should add support for other processors.

Ref: https://github.com/sthima/libstapsdt/issues/1