### PR TITLE
src: add isenabled functionality

### DIFF
--- a/src/asm/libstapsdt-x86_64.s
+++ b/src/asm/libstapsdt-x86_64.s
@@ -6,6 +6,9 @@
 
 _funcStart:
   nop
+  nop
+  nop
+  nop
   ret
 _funcEnd:
   nop

--- a/src/libstapsdt.c
+++ b/src/libstapsdt.c
@@ -149,6 +149,13 @@ void probeFire(SDTProbe_t *probe, ...) {
   }
 }
 
+int probeIsEnabled(SDTProbe_t *probe) {
+  if(((*(char *)probe->_fire) & 0x90) == 0x90) {
+    return 0;
+  }
+  return 1;
+}
+
 void providerDestroy(SDTProvider_t *provider) {
   SDTProbeList_t *node=NULL, *next=NULL;
   for(node=provider->probes; node!=NULL; node=next) {

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -45,4 +45,6 @@ void providerDestroy(SDTProvider_t *provider);
 
 void probeFire(SDTProbe_t *probe, ...);
 
+int probeIsEnabled(SDTProbe_t *probe);
+
 #endif


### PR DESCRIPTION
Is-enabled is a nice feature which allows current process to know if
it's being traced at a certain probe point. This feature is also defined
in the libusdt API, and we want to have a compatible API with them, thus
another reason to implement it.

Fixes: https://github.com/sthima/libstapsdt/issues/8