### PR TITLE
docs: Add arguments explanation to functions docs

### DIFF
--- a/docs/api/functions.rst
+++ b/docs/api/functions.rst
@@ -9,6 +9,11 @@ Functions
   with all attributes correctly initialized and then returns a pointer to it,
   or ``NULL`` if there was an error.
 
+  :param string name: The name of this provider
+  :return: A pointer to the new provider
+  :rtype: SDTProvider_t*
+  :type str: const char*
+
 .. c:function:: SDTProbe_t *providerAddProbe(SDTProvider_t *provider, const char *name, int argCount, ...)
 
   This function received a :c:type:`SDTProvider_t` created by
@@ -18,6 +23,14 @@ Functions
   register it to the given :c:type:`SDTProvider_t`. The return would be a
   pointer to the created :c:type:`SDTProbe_t`, or ``NULL`` if there was an
   error.
+
+  :param SDTProvider_t* provider: The provider where this probe will be created
+  :param string name: The name of this probe
+  :param int argCount: The number of arguments accepted by this probe
+  :param SDTArgTypes_t ...: Any number of arguments (number of arguments must
+    match argCount)
+  :return: A pointer to the new provider
+  :rtype: SDTProbe_t*
 
 .. c:function:: int providerLoad(SDTProvider_t *provider)
 
@@ -29,6 +42,11 @@ Functions
   available for tracing, and you shouldn't add new probes or load this
   provider again.
 
+  :param SDTProvider_t* provider: The provider to be loaded
+  :return: A status code (``0`` means success, other numbers indicates error)
+  :rtype: int
+
+
 .. c:function:: int providerUnload(SDTProvider_t *provider)
 
   Once you don't want your probes to be available anymore, you can call this
@@ -39,16 +57,31 @@ Functions
   After calling this function all probes will be unavailable for tracing, and
   you can add new probes to the provider again.
 
+  :param SDTProvider_t* provider: The provider to be unloaded
+  :return: A status code (``0`` means success, other numbers indicates error)
+  :rtype: int
+
 .. c:function:: void providerDestroy(SDTProvider_t *provider)
 
   This function frees a :c:type:`SDTProvider_t` from memory, along with all
   registered :c:type:`SDTProbe_t` created with :c:func:`providerAddProbe`.
+
+  :param SDTProvider_t* provider: The provider to be freed from memory, along
+    with it's probes
 
 .. c:function:: void probeFire(SDTProbe_t *probe, ...)
 
   This function fires a probe if it's available for tracing (which means it
   will only fire the probe if :c:func:`providerLoad` was called before).
 
+  :param SDTProbe_t* probe: The probe to be fired
+  :param any ...: Any number of arguments (must match the expected
+    number of arguments for this probe)
+
 .. c:function:: int probeIsEnabled(SDTProbe_t *probe)
 
   This function returns ``1`` if the probe is being traced, or ``0`` otherwise.
+
+  :param SDTProbe_t* probe: The probe to be checked
+  :return: ``1`` if probe is enabled, ``0`` otherwise
+  :rtype: int


### PR DESCRIPTION
There was only a textual explanation for the functions. Having all
parameters listed helps a quicker look at those functions, and reading
the explanation is only needed the first time (or if trying to better
understand the API).