### PR TITLE
src: Remove shared library on provider unload

### DIFF
--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -34,6 +34,7 @@ typedef struct SDTProvider {
   char *name;
   SDTProbeList_t *probes;
   void *_handle;
+  char *_filename;
 } SDTProvider_t;
 
 SDTProvider_t *providerInit(const char *name);


### PR DESCRIPTION
Provider unload was correctly cleaning memory and unreferencing symbols,
but the shared library created on load wasn't being removed. We don't
need to keep the shared library, because if the provider is loaded again
it will need to create a new file anyway.

Fixex: https://github.com/sthima/libstapsdt/issues/3