### PR TITLE
Give the SDTProbe struct a name

### DIFF
--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -25,7 +25,7 @@ typedef enum {
 
 struct SDTProvider;
 
-typedef struct  {
+typedef struct SDTProbe {
   char *name;
   ArgType_t argFmt[MAX_ARGUMENTS];
   void *_fire;


### PR DESCRIPTION
As it stands, the absence of a name confuses the heck out of the cgo code generator. The type ends up being named `struct___0` which is a little tough to follow.