### PR TITLE
Indicate that libraries do not require execstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 CC=gcc
 CFLAGS= -std=gnu11
-LDFLAGS=-lelf -ldl
+LDFLAGS=-lelf -ldl -Wl,-z,noexecstack
 VERSION=0.1.0
 
 PREFIX=/usr

--- a/src/shared-lib.c
+++ b/src/shared-lib.c
@@ -50,7 +50,7 @@ Elf64_Ehdr *createElfHeader(Elf *elf) {
 }
 
 int createElfProgramHeaders(DynElf *dynElf) {
-  if ((dynElf->phdrLoad1 = elf64_newphdr(dynElf->elf, 3)) == NULL) {
+  if ((dynElf->phdrLoad1 = elf64_newphdr(dynElf->elf, 4)) == NULL) {
     // TODO (mmarchini) error message
     // FIXME (mmarchini) properly free everything
     return -1;
@@ -58,6 +58,7 @@ int createElfProgramHeaders(DynElf *dynElf) {
 
   dynElf->phdrDyn = &dynElf->phdrLoad1[2];
   dynElf->phdrLoad2 = &dynElf->phdrLoad1[1];
+  dynElf->phdrStack = &dynElf->phdrLoad1[3];
 
   return 0;
 }
@@ -435,6 +436,16 @@ int dynElfSave(DynElf *dynElf) {
   dynElf->phdrDyn->p_filesz = dynElf->sections.dynamic->data->d_size;
   dynElf->phdrDyn->p_memsz = dynElf->sections.dynamic->data->d_size;
   dynElf->phdrDyn->p_align = 0x8; // XXX magic number?
+
+  // GNU_STACK PHDR
+  dynElf->phdrStack->p_type = PT_GNU_STACK;
+  dynElf->phdrStack->p_flags = PF_W + PF_R;
+  dynElf->phdrStack->p_offset = 0;
+  dynElf->phdrStack->p_vaddr = 0;
+  dynElf->phdrStack->p_paddr = 0;
+  dynElf->phdrStack->p_filesz = 0;
+  dynElf->phdrStack->p_memsz = 0;
+  dynElf->phdrStack->p_align = 0x10;
 
   // Fix offsets DynSym
   // ----------------------------------------------------------------------- //

--- a/src/shared-lib.h
+++ b/src/shared-lib.h
@@ -22,7 +22,7 @@ typedef struct {
 typedef struct {
   Elf *elf;
   Elf64_Ehdr *ehdr;
-  Elf64_Phdr *phdrLoad1, *phdrLoad2, *phdrDyn;
+  Elf64_Phdr *phdrLoad1, *phdrLoad2, *phdrDyn, *phdrStack;
 
   StringTable *stringTable;
   StringTable *dynamicString;


### PR DESCRIPTION
These two changes indicate to the loader that neither libstapsdt.so nor the generated anonymous .so require executable stacks. The changes were motivated by the lack of support for executable stacks on Windows Subsystem for Linux (WSL) but non-executable stack memory is also a good thing from a library hardening perspective (protection from buffer overruns).

To verify that the libraries have the expected header one can run `readelf -l <the_library.so>` and look for the `GNU_STACK` header. It will have all zeros for offset/size/addr and the value `RW` for flags.

```
Type           Offset             VirtAddr           PhysAddr
               FileSiz            MemSiz              Flags  Align
GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
               0x0000000000000000 0x0000000000000000  RW     10
```