### PR TITLE
Support for memory-backed file descriptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: c
 
 compiler: gcc
-dist: trusty
 sudo: required
+
+jobs:
+  include:
+    - os: linux
+      dist: trusty
+    - os: linux
+      dist: bionic
 
 before_install:
   - sudo apt-get -qq update

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CC=gcc
-CFLAGS= -std=gnu11
+CFLAGS= -std=gnu11 $(CFLAGS_EXTRA)
 LDFLAGS=-lelf -ldl -Wl,-z,noexecstack
 VERSION=0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CC=gcc
-CFLAGS= -std=gnu11 $(CFLAGS_EXTRA)
+CFLAGS= -std=gnu11
 LDFLAGS=-lelf -ldl -Wl,-z,noexecstack
 VERSION=0.1.0
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -8,7 +8,7 @@
 
 const char *sdtErrors[] = {
   "failed to create Elf shared library for provider '%s'",
-  "failed to create temporary file '%s'",
+  "failed to create temporary file",
   "failed to open shared library '%s': %s",
   "failed to load symbol '%s' for shared library '%s': %s",
   "failed to close shared library '%s' for provider '%s': %s",

--- a/src/libstapsdt.c
+++ b/src/libstapsdt.c
@@ -62,9 +62,9 @@ SDTProvider_t *providerInit(const char *name) {
 
   provider->_memfd = -1;
 #ifdef HAVE_LIBSTAPSDT_MEMORY_BACKED_FD
-  provider->_use_memfd = 1;
+  provider->_use_memfd = memfd_enabled;
 #else
-  provider->_use_memfd = 0;
+  provider->_use_memfd = memfd_disabled;
 #endif
 
   provider->name = (char *) calloc(sizeof(char), strlen(name) + 1);
@@ -73,7 +73,7 @@ SDTProvider_t *providerInit(const char *name) {
   return provider;
 }
 
-int providerUseMemfd(SDTProvider_t *provider, const int use_memfd) {
+int providerUseMemfd(SDTProvider_t *provider, const MemFD_Option_t use_memfd) {
 #ifdef HAVE_LIBSTAPSDT_MEMORY_BACKED_FD
   // Changing use of memfd must be done while provider is not loaded.
   if(provider && !provider->_handle) {
@@ -118,7 +118,7 @@ SDTProbe_t *providerAddProbe(SDTProvider_t *provider, const char *name, int argC
 static char *tempElfPath(int *fd, const char *name, const int use_memfd) {
   char *filename = NULL;
 #ifdef HAVE_LIBSTAPSDT_MEMORY_BACKED_FD
-  if(use_memfd) {
+  if(use_memfd == memfd_enabled) {
     char path_buffer[PATH_MAX];
     snprintf(path_buffer, sizeof(path_buffer), "libstapsdt:%s", name);
 
@@ -151,7 +151,7 @@ int providerLoad(SDTProvider_t *provider) {
   char *error;
 
   provider->_filename = tempElfPath(&fd, provider->name, provider->_use_memfd);
-  if(provider->_use_memfd) {
+  if(provider->_use_memfd == memfd_enabled) {
     provider->_memfd = fd;
   }
   if (provider->_filename == NULL) {

--- a/src/libstapsdt.c
+++ b/src/libstapsdt.c
@@ -22,12 +22,12 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0)
 #include <linux/memfd.h>
+#include <linux/fcntl.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 
 #ifdef __NR_memfd_create // older glibc may not have this syscall defined
 #define HAVE_LIBSTAPSDT_MEMORY_BACKED_FD
-#define F_SEAL_SEAL 0x0001 /* prevent further seals from being set */
 // Note that linux must be 3.17 or greater to support this
 static inline int memfd_create(const char *name, unsigned int flags) {
   return syscall(__NR_memfd_create, name, flags);

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -23,6 +23,11 @@ typedef enum {
   int64 = -8,
 } ArgType_t;
 
+typedef enum {
+  memfd_disabled = 0,
+  memfd_enabled = 1,
+} MemFD_Option_t;
+
 struct SDTProvider;
 
 typedef struct SDTProbe {
@@ -48,7 +53,7 @@ typedef struct SDTProvider {
   void *_handle;
   char *_filename;
   int _memfd;
-  int _use_memfd;
+  MemFD_Option_t _use_memfd;
 } SDTProvider_t;
 
 SDTProvider_t *providerInit(const char *name);
@@ -56,10 +61,10 @@ SDTProvider_t *providerInit(const char *name);
 /*
 Linux newer than 3.17 with libc that supports the syscall it will default to
 using a memory-backed file descriptor. This behavior can be overridden at
-runtime by calling this with use_memfd = 0 prior after providerInit, and before
+runtime by calling this with use_memfd = memfd_disabled prior after providerInit, and before
 providerLoad.
 */
-int providerUseMemfd(SDTProvider_t *provider, const int use_memfd);
+int providerUseMemfd(SDTProvider_t *provider, const MemFD_Option_t use_memfd);
 
 SDTProbe_t *providerAddProbe(SDTProvider_t *provider, const char *name, int argCount, ...);
 

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -47,6 +47,7 @@ typedef struct SDTProvider {
   // private
   void *_handle;
   char *_filename;
+  int _memfd;
 } SDTProvider_t;
 
 SDTProvider_t *providerInit(const char *name);

--- a/src/libstapsdt.h
+++ b/src/libstapsdt.h
@@ -48,9 +48,18 @@ typedef struct SDTProvider {
   void *_handle;
   char *_filename;
   int _memfd;
+  int _use_memfd;
 } SDTProvider_t;
 
 SDTProvider_t *providerInit(const char *name);
+
+/*
+Linux newer than 3.17 with libc that supports the syscall it will default to
+using a memory-backed file descriptor. This behavior can be overridden at
+runtime by calling this with use_memfd = 0 prior after providerInit, and before
+providerLoad.
+*/
+int providerUseMemfd(SDTProvider_t *provider, const int use_memfd);
 
 SDTProbe_t *providerAddProbe(SDTProvider_t *provider, const char *name, int argCount, ...);
 


### PR DESCRIPTION
This abstracts the creation of the temporary ELF file to allow for two possible approaches:

- The current (default) approach of allocating a temporary file to `/tmp` and dlopen'ing it 
- A new (optional) approach, to use a memory-backed file descriptor, if `LIBSTAPSDT_MEMORY_BACKED_FD` is specified.

The new approach his beneficial for two reasons:

- There is no need to clean up the file, it is automatically removed when the process dies (the primary reason for this approach).
- No calls are made to the underlying filesystem, everything is done in memory. While tmpfs is probably already memory-based, this could be advantageous in some circumstances.

libusdt does something similar, where it just [valloc's directly into the processes address space](https://github.com/chrisa/libusdt/blob/master/usdt_probe.c#L99), so there is no need for a temporary file to clean up.

Overall, I find that doing tho whole thing in memory and having it be automatically cleaned up with the process's lifecycle is a bit more elegant.

The drawbacks to this approach are:

- ~It is not yet supported by bcc, but I've submitted https://github.com/iovisor/bcc/pull/2314 to show how this could be utilized.~ Support has been added to BCC by https://github.com/iovisor/bcc/pull/2314
- If a large number of providers are allocated, the process will have a large number of file descriptors open. This is probably not a problem in practice.
- Support for `memfd_create` was not added until linux 3.17 (not a problem in practice, as BCC needs 4.1+ to do anything meaningful with eBPF) and glibc 2.27. The system call may not be defined on some systems.

I think the drawbacks are mitigated by hiding it behind a preprocessor macro check, as the behavior remains unchanged. In the future, hopefully once https://github.com/iovisor/bcc/pull/2314 is in a major bcc release, we could remove the macro and default to a memory-based shared object, falling back to temporary file if we detect that `memfd_create` is not supported.

Attaching a probe (`global:helloworld`) this way, the resulting process looks like:

/proc/${PID}/maps:

```
...
7f9e79f0c000-7f9e79f0d000 r-xp 00000000 00:05 11706507                   /memfd:libstapsdt:global (deleted)
7f9e79f0d000-7f9e7a10c000 ---p 00001000 00:05 11706507                   /memfd:libstapsdt:global (deleted)
7f9e7a10c000-7f9e7a10d000 rw-p 00000000 00:05 11706507                   /memfd:libstapsdt:global (deleted)
...
```

And if we check out the file descriptors for the process:

```
lrwx------ 1 dale.hamel dale.hamel 64 Apr 14 20:57 7 -> '/memfd:libstapsdt:global (deleted)'
```

So if we check for elf notes on that fd:

```
$readelf --notes /proc/${PID}/fd/7

Displaying notes found in: .note.stapsdt
  Owner                 Data size       Description
  stapsdt              0x00000039       NT_STAPSDT (SystemTap probe descriptors)
    Provider: global
    Name: helloword
    Location: 0x0000000000000260, Base: 0x0000000000000318, Semaphore: 0x0000000000000000
    Arguments: 8@%rdi -8@%rsi
```

And if I run tplist -p
```
$ tplist -p ${PID} | grep global
/proc/12646/fd/7 global:hello_nsec
```

Or use my latest branch of bpftrace with wildcard USDT support:
```
$ bpftrace -l 'usdt:*:global:*' -p ${PID}
usdt:/proc/12646/fd/7:global:helloworld
```

I can attach to the probe by that path, or by PID (using my bcc branch)

If I disable the provider, the file descriptor is closed and the elf file is removed from the memory map.
