### PR TITLE
Use clang for tests as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
 
-compiler: gcc
+compiler: 
+  - gcc
+  - clang
 dist: trusty
 sudo: required
 


### PR DESCRIPTION
Compile tests using clang and gcc. This would be useful to detect possible, albeit unlikely code that breaks under clang.

As per [the docs](https://docs.travis-ci.com/user/languages/c/) this should set `CC` env variable accordingly 